### PR TITLE
removing some used "unused" variables

### DIFF
--- a/src/Database.zig
+++ b/src/Database.zig
@@ -1704,7 +1704,6 @@ pub fn format(
     options: std.fmt.FormatOptions,
     writer: anytype,
 ) !void {
-    _ = db;
     _ = options;
     _ = fmt;
     try writer.writeAll("Regz Database:\n");

--- a/src/svd.zig
+++ b/src/svd.zig
@@ -424,7 +424,6 @@ pub const RegisterProperties = struct {
     reset_mask: ?u64,
 
     pub fn parse(arena: *ArenaAllocator, nodes: *xml.Node) !RegisterProperties {
-        _ = arena;
         return RegisterProperties{
             .size = try xml.parseIntForKey(u16, arena.child_allocator, nodes, "size"),
             .reset_value = try xml.parseIntForKey(u64, arena.child_allocator, nodes, "resetValue"),


### PR DESCRIPTION
On the newest version of the zig compiler, it doesn't like params which are used looking like unused variables. I was getting 
```
/dev/git/regz/src/svd.zig:427:13: error: pointless discard of function parameter
        _ = arena;
            ^~~~~
/dev/git/regz/src/svd.zig:431:55: note: used here
            .reset_mask = try xml.parseIntForKey(u64, arena.child_allocator, nodes, "resetMask"),
                                                      ^~~~~
/dev/git/regz/src/Database.zig:1707:9: error: pointless discard of function parameter
    _ = db;
        ^~
/home/freied/dev/git/regz/src/Database.zig:1731:14: note: used here
        for (db.fields.items) |field, i|
             ^~
error: regz...
```