### PR TITLE
rebuild on zig master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ const LibExeObjStep = std.build.LibExeObjStep;
 const Step = std.build.Step;
 const GeneratedFile = std.build.GeneratedFile;
 
-pub fn build(b: *std.build.Builder) !void {
+pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
@@ -33,12 +33,12 @@ pub fn build(b: *std.build.Builder) !void {
         .target = target,
         .optimize = optimize,
     });
-    regz.addModule("clap", clap_dep.module("clap"));
+    regz.root_module.addImport("clap", clap_dep.module("clap"));
     regz.linkLibrary(libxml2_dep.artifact("xml2"));
     b.installArtifact(regz);
 
     _ = b.addModule("regz", .{
-        .source_file = .{ .path = "src/module.zig" },
+        .root_source_file = .{ .path = "src/module.zig" },
     });
 
     const run_cmd = b.addRunArtifact(regz);
@@ -55,6 +55,7 @@ pub fn build(b: *std.build.Builder) !void {
         .root_source_file = .{
             .path = "src/contextualize-fields.zig",
         },
+        .target = target,
     });
     contextualize_fields.linkLibrary(libxml2_dep.artifact("xml2"));
     const contextualize_fields_run = b.addRunArtifact(contextualize_fields);
@@ -69,6 +70,7 @@ pub fn build(b: *std.build.Builder) !void {
         .root_source_file = .{
             .path = "src/characterize.zig",
         },
+        .target = target,
     });
     characterize.linkLibrary(libxml2_dep.artifact("xml2"));
     const characterize_run = b.addRunArtifact(characterize);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,12 +12,14 @@
     },
     .dependencies = .{
         .libxml2 = .{
-            .url = "https://github.com/mitchellh/zig-build-libxml2/archive/4e80a167d6e13e09e0da77457310401084e758cc.tar.gz",
-            .hash = "1220000fd2a0f192b1aab0c12be0080748e774044399d69a852ffa38a58f2b1dcc09",
+            // temporary use fork until https://github.com/mitchellh/zig-build-libxml2/pull/1 gets merged or issue
+            // gets resolved directly in upstream.
+            .url = "https://github.com/ianprime0509/zig-build-libxml2/archive/4d1b7db156b0e7a19127c652adefdf27799770ab.tar.gz",
+            .hash = "122011b13203141cc965cfe6b070ffb5a8835eb906bb2cfd4650dbc17574e6e36fd5",
         },
         .clap = .{
-            .url = "https://github.com/Hejsil/zig-clap/archive/f49b94700e0761b7514abdca0e4f0e7f3f938a93.tar.gz",
-            .hash = "1220f48518ce22882e102255ed3bcdb7aeeb4891f50b2cdd3bd74b5b2e24d3149ba2",
+            .url = "https://github.com/Hejsil/zig-clap/archive/9c23bcb5aebe0c2542b4de4472f60959974e2222.tar.gz",
+            .hash = "12209e829da9d7d0bc089e4e0cbc07bb882f6192cd583277277da34df53cd05b8f2a",
         },
     },
     .paths = .{""},

--- a/src/Database.zig
+++ b/src/Database.zig
@@ -767,7 +767,7 @@ pub fn add_child(
     // the tables are in plural form but "type.peripheral" feels better to me
     // for calling this function
     comptime _ = it.next();
-    comptime var table = (it.next() orelse unreachable) ++ "s";
+    const table = comptime (it.next() orelse unreachable) ++ "s";
 
     const result = try @field(db.children, table).getOrPut(db.gpa, parent_id);
     if (!result.found_existing)
@@ -799,8 +799,8 @@ pub fn entity_is(db: Database, comptime entity_location: []const u8, id: EntityI
     comptime var it = std.mem.tokenize(u8, entity_location, ".");
     // the tables are in plural form but "type.peripheral" feels better to me
     // for calling this function
-    comptime var group = (it.next() orelse unreachable) ++ "s";
-    comptime var table = (it.next() orelse unreachable) ++ "s";
+    const group = comptime (it.next() orelse unreachable) ++ "s";
+    const table = comptime (it.next() orelse unreachable) ++ "s";
 
     // TODO: nice error messages, like group should either be 'type' or 'instance'
     return @field(@field(db, group), table).contains(id);
@@ -814,8 +814,8 @@ pub fn get_entity_id_by_name(
     comptime var tok_it = std.mem.tokenize(u8, entity_location, ".");
     // the tables are in plural form but "type.peripheral" feels better to me
     // for calling this function
-    comptime var group = (tok_it.next() orelse unreachable) ++ "s";
-    comptime var table = (tok_it.next() orelse unreachable) ++ "s";
+    const group = comptime (tok_it.next() orelse unreachable) ++ "s";
+    const table = comptime (tok_it.next() orelse unreachable) ++ "s";
 
     return for (@field(@field(db, group), table).keys()) |id| {
         const entry_name = db.attrs.name.get(id) orelse continue;

--- a/src/atdf.zig
+++ b/src/atdf.zig
@@ -1145,7 +1145,7 @@ test "atdf.register with bitfields and enum" {
         \\  </modules>
         \\</avr-tools-device-file>
     ;
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_atdf(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1271,7 +1271,7 @@ test "atdf.register with mode" {
         \\
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_atdf(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1394,7 +1394,7 @@ test "atdf.instance of register group" {
         \\
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_atdf(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1433,7 +1433,7 @@ test "atdf.interrupts" {
         \\
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_atdf(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1459,7 +1459,7 @@ test "atdf.interrupts with module-instance" {
         \\
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_atdf(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1492,7 +1492,7 @@ test "atdf.interrupts with interrupt-groups" {
         \\
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_atdf(std.testing.allocator, doc);
     defer db.deinit();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -47,6 +47,7 @@ fn main_impl() anyerror!void {
 
     var diag = clap.Diagnostic{};
     var res = clap.parse(clap.Help, &params, clap.parsers.default, .{
+        .allocator = allocator,
         .diagnostic = &diag,
     }) catch |err| {
         // Report useful error and exit

--- a/src/svd.zig
+++ b/src/svd.zig
@@ -772,7 +772,7 @@ test "svd.device register properties" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -815,7 +815,7 @@ test "svd.peripheral register properties" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -861,7 +861,7 @@ test "svd.register register properties" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -906,7 +906,7 @@ test "svd.register with fields" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -959,7 +959,7 @@ test "svd.field with enum value" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1014,7 +1014,7 @@ test "svd.peripheral with dimElementGroup" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1052,7 +1052,7 @@ test "svd.peripheral with dimElementgroup, dimIndex set" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1088,7 +1088,7 @@ test "svd.register with dimElementGroup" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1129,7 +1129,7 @@ test "svd.register with dimElementGroup, dimIncrement != size" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1166,7 +1166,7 @@ test "svd.register with dimElementGroup, suffixed with [%s]" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1200,7 +1200,7 @@ test "svd.register with dimElementGroup, %s in name" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 
@@ -1241,7 +1241,7 @@ test "svd.field with dimElementGroup, suffixed with %s" {
         \\</device>
     ;
 
-    var doc = try xml.Doc.from_memory(text);
+    const doc = try xml.Doc.from_memory(text);
     var db = try Database.init_from_svd(std.testing.allocator, doc);
     defer db.deinit();
 

--- a/src/xml.zig
+++ b/src/xml.zig
@@ -46,16 +46,14 @@ pub const Node = struct {
         };
 
         pub fn next(it: *AttrIterator) ?Entry {
-            return if (it.attr) |attr| ret: {
-                if (attr.name) |name|
-                    if (@as(*c.xmlNode, @ptrCast(attr.children)).content) |content| {
-                        defer it.attr = attr.next;
-                        break :ret Entry{
-                            .key = std.mem.span(name),
-                            .value = std.mem.span(content),
-                        };
-                    };
-            } else null;
+            const attr = it.attr orelse return null;
+            const name = attr.name orelse return null;
+            const content = @as(*c.xmlNode, @ptrCast(attr.children)).content orelse return null;
+            it.attr = attr.next;
+            return .{
+                .key = std.mem.span(name),
+                .value = std.mem.span(content),
+            };
         }
     };
 


### PR DESCRIPTION
This CL adds support to build regz with the latest zig nightlies. Zig renamed a few fields and made the compiler a bit more restrictive around constants and comptime.